### PR TITLE
Support configuring the baseURL

### DIFF
--- a/Courier/Courier.swift
+++ b/Courier/Courier.swift
@@ -1,22 +1,26 @@
 import Foundation
 
 public struct Courier {
+  static let defaultBaseURL = NSURL(string: "https://courier.thoughtbot.com/")!
+
   public let apiKey: String
   public let apiVersion = 1
 
   let urlSession: URLSession
-  let courierURL = NSURL(string: "https://courier.thoughtbot.com/")!
+  let baseURL: NSURL
 
   public init(
     apiKey: String,
-    urlSession: URLSession = NSURLSession.sharedSession()
+    urlSession: URLSession = NSURLSession.sharedSession(),
+    baseURL: NSURL = defaultBaseURL
   ) {
     self.apiKey = apiKey
     self.urlSession = urlSession
+    self.baseURL = baseURL
   }
 
   public func subscribeToChannel(channel: String, withToken token: NSData) {
-    let channelURL = courierURL.URLByAppendingPathComponent("subscribe").URLByAppendingPathComponent(parameterizeString((channel)))
+    let channelURL = baseURL.URLByAppendingPathComponent("subscribe").URLByAppendingPathComponent(parameterizeString((channel)))
 
     let request = NSMutableURLRequest(URL: channelURL)
     request.HTTPMethod = "PUT"

--- a/CourierTests/CourierSpec.swift
+++ b/CourierTests/CourierSpec.swift
@@ -80,6 +80,15 @@ class CourierSpec: QuickSpec {
         let body = try! NSJSONSerialization.JSONObjectWithData(session.lastRequest!.HTTPBody!, options: []) as! NSDictionary
         expect(body).to(equal(["device": ["token": token]] as NSDictionary))
       }
+
+      it("supports changing the default base URL") {
+        let session = TestURLSession()
+        let courier = Courier(apiKey: "", urlSession: session, baseURL: NSURL(string: "https://example.com")!)
+
+        courier.subscribeToChannel("channel", withToken: NSData())
+
+        expect(session.lastRequest?.URL) == NSURL(string: "https://example.com/subscribe/channel")
+      }
     }
   }
 }


### PR DESCRIPTION
To make it easier to test against staging without having to rebuild the framework.
