### PR TITLE
Decouple token channel subscription

### DIFF
--- a/Courier/Courier.swift
+++ b/Courier/Courier.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Courier {
+public final class Courier {
   static let defaultBaseURL = NSURL(string: "https://courier.thoughtbot.com/")!
 
   public let apiToken: String
@@ -13,6 +13,18 @@ public struct Courier {
   private let specialCharactersRegex = try! NSRegularExpression(pattern: "[^a-z0-9\\-_]+", options: .CaseInsensitive)
   private let leadingTrailingSeparatorRegex = try! NSRegularExpression(pattern: "^-|-$", options: .CaseInsensitive)
   private let repeatingSeperatorRegex = try! NSRegularExpression(pattern: "-{2,}", options: .CaseInsensitive)
+
+  private var userDefaultsKey: String {
+    return "com.thoughtbot.courier.\(apiToken).device_token"
+  }
+  public var deviceToken: NSData? {
+    get {
+      return NSUserDefaults.standardUserDefaults().dataForKey(userDefaultsKey)
+    }
+    set {
+      NSUserDefaults.standardUserDefaults().setObject(newValue, forKey: userDefaultsKey)
+    }
+  }
 
   public init(
     apiToken: String,
@@ -27,6 +39,8 @@ public struct Courier {
   }
 
   public func subscribeToChannel(channel: String, withToken token: NSData) {
+    deviceToken = token
+
     guard let url = URLForChannel(channel, environment: environment) else {
       fatalError("Failed to URL for channel: \(channel) for environment: \(environment)")
     }

--- a/Courier/Courier.swift
+++ b/Courier/Courier.swift
@@ -38,12 +38,25 @@ public final class Courier {
     self.environment = environment
   }
 
+  public func subscribeToChannel(channel: String) {
+    guard let deviceToken = deviceToken else {
+      preconditionFailure(
+        "Cannot subscribe to a channel without a device token."
+        + "Set courier.deviceToken in your"
+        + "UIApplicationDelegate application(_:didRegisterForRemoteNotificationsWithDeviceToken:)"
+      )
+    }
+
+    subscribeToChannel(channel, withToken: deviceToken)
+  }
+
   public func subscribeToChannel(channel: String, withToken token: NSData) {
     deviceToken = token
 
     guard let url = URLForChannel(channel, environment: environment) else {
-      fatalError("Failed to URL for channel: \(channel) for environment: \(environment)")
+      fatalError("Failed to create URL for channel: \(channel) in environment: \(environment)")
     }
+
     let request = NSMutableURLRequest(URL: url)
     request.HTTPMethod = "PUT"
     request.setValue("Token token=\(apiToken)", forHTTPHeaderField: "Authorization")

--- a/CourierTests/CourierSpec.swift
+++ b/CourierTests/CourierSpec.swift
@@ -32,6 +32,20 @@ class CourierSpec: QuickSpec {
       }
     }
 
+    context("subscribeToChannel") {
+      it("subscribes to the channel using a previously registered token") {
+        let session = TestURLSession()
+        let courier = Courier(apiToken: "", urlSession: session)
+        let token = "93b40fbcf25480d515067ba49f98620e4ef38bdf7be9da6275f80c4f858f5ce2"
+
+        courier.deviceToken = dataFromHexadecimalString(token)!
+        courier.subscribeToChannel("Test")
+
+        let body = try! NSJSONSerialization.JSONObjectWithData(session.lastRequest!.HTTPBody!, options: []) as! NSDictionary
+        expect(body).to(equal(["device": ["token": token]] as NSDictionary))
+      }
+    }
+
     context("subscribeToChannel(withToken:)") {
       it("requests the /subscribe/[token] endpoint") {
         let session = TestURLSession()


### PR DESCRIPTION
Decouples registering a token from subscribing to a channel so that they can happen at different times in the lifecycle of an app.

Consider a typical situation where push notifications are registered after a user signs in. Assume permissions for push notifications have been granted already.

1. App launches and immediately receives the `application(_:didRegisterForRemoteNotificationsWithDeviceToken)` delegate
2. User signs in

At step 1 a developer can't register for a channel because it needs the user model to determine the channel name. At step 2 a developer can't register because the device token is only available in the delegate callback. Unless of course the developer has done additional work to make it available.

With this change the situation changes as follows:

1. App launches and receives callback
2. Device token is saved in user defaults using `courier.deviceToken = deviceToken`
3. User signs in
4. User is subscribed to a channel using `courier.subscribeToChannel(user.uuid)`

In essence we've done the extra work for the developer by saving the device token in user defaults whenever the device token is set.