### PR TITLE
Don't namespace device token user defaults key

### DIFF
--- a/Courier/Courier.swift
+++ b/Courier/Courier.swift
@@ -17,7 +17,7 @@ public final class Courier {
   private let repeatingSeperatorRegex = try! NSRegularExpression(pattern: "-{2,}", options: .CaseInsensitive)
 
   private var userDefaultsKey: String {
-    return "com.thoughtbot.courier.\(apiToken).device_token"
+    return "com.thoughtbot.courier.device_token"
   }
   public var deviceToken: NSData? {
     get {

--- a/CourierTests/CourierSpec.swift
+++ b/CourierTests/CourierSpec.swift
@@ -13,7 +13,7 @@ class CourierSpec: QuickSpec {
         courier.deviceToken = deviceToken
 
         let userDefaults = NSUserDefaults.standardUserDefaults()
-        let key = "com.thoughtbot.courier.\(apiToken).device_token"
+        let key = "com.thoughtbot.courier.device_token"
         expect(userDefaults.dataForKey(key)) == deviceToken
       }
 
@@ -22,13 +22,6 @@ class CourierSpec: QuickSpec {
         Courier(apiToken: "", environment: .Development).deviceToken = deviceToken
 
         expect(Courier(apiToken: "", environment: .Development).deviceToken) == deviceToken
-      }
-
-      it("uses different tokens for instances with different API tokens") {
-        let deviceToken = "DEVICE_TOKEN".dataUsingEncoding(NSUTF8StringEncoding)
-        Courier(apiToken: "1", environment: .Development).deviceToken = deviceToken
-
-        expect(Courier(apiToken: "2", environment: .Development).deviceToken).to(beNil())
       }
     }
 
@@ -345,9 +338,7 @@ class CourierSpec: QuickSpec {
     }
 
     afterEach {
-      let userDefaults = NSUserDefaults.standardUserDefaults()
-      let dictionary = userDefaults.dictionaryRepresentation()
-      dictionary.keys.forEach(userDefaults.removeObjectForKey)
+      NSUserDefaults.standardUserDefaults().removeObjectForKey("com.thoughtbot.courier.device_token")
     }
   }
 }


### PR DESCRIPTION
They device token is unique per app and device. There is no need to
store the device token unique per API token because every API token will
get the same device token.